### PR TITLE
fix: pre-stop throws error if project not running

### DIFF
--- a/src/Mutagen.ts
+++ b/src/Mutagen.ts
@@ -71,7 +71,7 @@ export class Mutagen {
     }
     stop(mutagenConfigFile: string) {
         // If the project is running, stop it.
-        if (this.isRunning) {
+        if (this.isRunning(mutagenConfigFile)) {
             try {
                 this.logger.verbose(`stopping mutagen`);
                 const stdout = process.execSync(`mutagen project terminate -f ${mutagenConfigFile}`);

--- a/src/Mutagen.ts
+++ b/src/Mutagen.ts
@@ -60,6 +60,14 @@ export class Mutagen {
     }
     stop(mutagenConfigFile: string) {
         try {
+            // Check if the mutagen project is running
+            process.execSync(`mutagen project list -f ${mutagenConfigFile}`);
+        }
+        catch (e) {
+            return;
+        }
+        // If the project is running, stop it.
+        try {
             this.logger.verbose(`stopping mutagen`);
             const stdout = process.execSync(`mutagen project terminate -f ${mutagenConfigFile}`);
             this.logger.verbose(`stopped mutagen: ${stdout}`);

--- a/src/Mutagen.ts
+++ b/src/Mutagen.ts
@@ -49,6 +49,17 @@ export class Mutagen {
         return true;
     }
 
+    isRunning(mutagenConfigFile: string): boolean {
+        try {
+            // Check if the mutagen project is running
+            process.execSync(`mutagen project list -f ${mutagenConfigFile}`);
+        }
+        catch (e) {
+            return false;
+        }
+        return true;
+    }
+
     start(mutagenConfigFile: string) {
         try {
             this.logger.verbose(`starting mutagen`);
@@ -59,20 +70,15 @@ export class Mutagen {
         }
     }
     stop(mutagenConfigFile: string) {
-        try {
-            // Check if the mutagen project is running
-            process.execSync(`mutagen project list -f ${mutagenConfigFile}`);
-        }
-        catch (e) {
-            return;
-        }
         // If the project is running, stop it.
-        try {
-            this.logger.verbose(`stopping mutagen`);
-            const stdout = process.execSync(`mutagen project terminate -f ${mutagenConfigFile}`);
-            this.logger.verbose(`stopped mutagen: ${stdout}`);
-        } catch (e) {
-            throw new MutagenProcessError(e);
+        if (this.isRunning) {
+            try {
+                this.logger.verbose(`stopping mutagen`);
+                const stdout = process.execSync(`mutagen project terminate -f ${mutagenConfigFile}`);
+                this.logger.verbose(`stopped mutagen: ${stdout}`);
+            } catch (e) {
+                throw new MutagenProcessError(e);
+            }
         }
     }
 }

--- a/src/MutagenConfigManipulator.ts
+++ b/src/MutagenConfigManipulator.ts
@@ -74,11 +74,15 @@ export class MutagenConfigManipulator {
         this.writeMutagenConfigFile(mutagenConfig, mutagenConfigOutputFile);
     }
 
-    removeManipulatedMutagenConfigFile(file: string) {
+    removeManipulatedMutagenConfigFile(file: string, softFail: boolean = false) {
         if (fs.existsSync(file)) {
             fs.unlinkSync(file);
         } else {
-            this.logger.verbose('Could not remove ' + file + ', because it does not exist');
+            if (softFail) {
+                this.logger.verbose('Could not remove ' + file + ', because it does not exist');
+            } else {
+                throw new MutagenConfigNotFoundError(file + ' does not exist');
+            }
         }
     }
 

--- a/src/MutagenConfigManipulator.ts
+++ b/src/MutagenConfigManipulator.ts
@@ -78,7 +78,7 @@ export class MutagenConfigManipulator {
         if (fs.existsSync(file)) {
             fs.unlinkSync(file);
         } else {
-            throw new MutagenConfigNotFoundError(file + ' does not exist');
+            this.logger.verbose('Could not remove ' + file + ', because it does not exist');
         }
     }
 

--- a/src/MutagenConfigManipulator.ts
+++ b/src/MutagenConfigManipulator.ts
@@ -74,7 +74,7 @@ export class MutagenConfigManipulator {
         this.writeMutagenConfigFile(mutagenConfig, mutagenConfigOutputFile);
     }
 
-    removeManipulatedMutagenConfigFile(file: string, softFail: boolean = false) {
+    removeManipulatedMutagenConfigFile(file: string, softFail = false) {
         if (fs.existsSync(file)) {
             fs.unlinkSync(file);
         } else {

--- a/src/MutagenConfigManipulator.ts
+++ b/src/MutagenConfigManipulator.ts
@@ -74,7 +74,7 @@ export class MutagenConfigManipulator {
         this.writeMutagenConfigFile(mutagenConfig, mutagenConfigOutputFile);
     }
 
-    removeManipulatedMutagenConfigFile(file: string, softFail = false) {
+    removeManipulatedMutagenConfigFile(file: string) {
         if (fs.existsSync(file)) {
             fs.unlinkSync(file);
         } else {

--- a/src/MutagenConfigManipulator.ts
+++ b/src/MutagenConfigManipulator.ts
@@ -78,11 +78,7 @@ export class MutagenConfigManipulator {
         if (fs.existsSync(file)) {
             fs.unlinkSync(file);
         } else {
-            if (softFail) {
-                this.logger.verbose('Could not remove ' + file + ', because it does not exist');
-            } else {
-                throw new MutagenConfigNotFoundError(file + ' does not exist');
-            }
+            throw new MutagenConfigNotFoundError(file + ' does not exist');
         }
     }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -61,7 +61,7 @@ export = (app: App) => {
         try {
             logger.info('stopping mutagen');
             mutagen.stop(mutagenConfigManipulatedFile);
-            mutagenConfigManipulator.removeManipulatedMutagenConfigFile(mutagenConfigManipulatedFile);
+            mutagenConfigManipulator.removeManipulatedMutagenConfigFile(mutagenConfigManipulatedFile, true);
             logger.info('stopped mutagen');
         }
         catch (e) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -61,7 +61,7 @@ export = (app: App) => {
         try {
             logger.info('stopping mutagen');
             mutagen.stop(mutagenConfigManipulatedFile);
-            mutagenConfigManipulator.removeManipulatedMutagenConfigFile(mutagenConfigManipulatedFile, true);
+            mutagenConfigManipulator.removeManipulatedMutagenConfigFile(mutagenConfigManipulatedFile);
             logger.info('stopped mutagen');
         }
         catch (e) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -65,7 +65,11 @@ export = (app: App) => {
             logger.info('stopped mutagen');
         }
         catch (e) {
-            handleError(e, logger);
+            if (e instanceof MutagenConfigNotFoundError) {
+                logger.verbose('mutagen config not found: ' + e.message);
+            } else {
+                handleError(e, logger);
+            }
         }
     });
 };


### PR DESCRIPTION
When the mutagen project was not running, but there was a .lando.mutagen.yml.tmp present, the plugin would throw an error. The .tmp file had to be manually deleted to get the project working again.

This fixes the issue by first checking if the project is running with the 'mutagen project list' command. Also, the plugin no longer throws an error if the .tmp file is not found, but it now prints a verbose line.