### PR TITLE
Start Sync From Subdirectory

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import { BaseError } from "./BaseError";
 import { Logger } from "./Logger";
 import { Mutagen, MutagenProcessError } from "./Mutagen";
 import { MutagenConfigInvalidError, MutagenConfigManipulator, MutagenConfigNotFoundError, MutagenConfigWriteError } from "./MutagenConfigManipulator";
+import { platform } from 'process';
 
 const handleError = (e: BaseError, logger: Logger) => {
     if (e instanceof MutagenConfigNotFoundError) {
@@ -23,8 +24,10 @@ const handleError = (e: BaseError, logger: Logger) => {
 };
 
 export = (app: App) => {
-    const mutagenConfigInputFile = '.lando.mutagen.yml';
-    const mutagenConfigManipulatedFile = '.lando.mutagen.yml.tmp';
+    let rootPath = app.root;
+    rootPath += (platform === "win32") ? '\\' : '/';
+    const mutagenConfigInputFile = rootPath + '.lando.mutagen.yml';
+    const mutagenConfigManipulatedFile = rootPath + '.lando.mutagen.yml.tmp';
 
     const logger = new Logger(app);
     const mutagen = new Mutagen(logger);

--- a/src/types/lando.d.ts
+++ b/src/types/lando.d.ts
@@ -17,6 +17,7 @@ declare module 'lando' {
         events: {
             on: (eventName: string, handler: () => void) => void;
         };
+        root: string;
     }
     class Lando {
         


### PR DESCRIPTION
This is a fix for the issue I created - https://github.com/francoisvdv/lando-mutagen/issues/115

Instead of using the filename like `.lando.mutagen.yml` and checking for things relative to where a command was run it gets the root path of the lando project from the config and uses the full path for the file instead.

I've gone through and tested this out on a Mac and everything is working as expected.  I don't have a windows machine to test this out on to make sure the file paths are working there.