### PR TITLE
Mac Install Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ This is where this plugin comes in. Add a base [Mutagen](https://mutagen.io) con
 2. Lando (obviously :))
 
 ## Installation
+### Mac Installation Script
+```
+curl -s https://raw.githubusercontent.com/francoisvdv/lando-mutagen/main/scripts/mac-install.sh | bash
+```
+The above command will download and run a script which installs the latest release of the plugin to `~/.lando/plugins/lando_mutagen`
 ### One-liner
 ```
 # rm -rf ~/.lando/plugins/lando-mutagen # Delete previous install

--- a/scripts/mac-install.sh
+++ b/scripts/mac-install.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+PLUGINS_DIR="$HOME/.lando/plugins"
+PLUGIN_PATH="$PLUGINS_DIR/lando_mutagen"
+ZIP_DOWNLOAD_PATH="$PLUGINS_DIR/lando_mutagen.zip"
+ZIP_DOWNLOAD_URL="https://github.com/francoisvdv/lando-mutagen/releases/latest/download/release.zip"
+
+check_if_command_exists()
+{
+    COMMAND=$1
+    if ! command -v "$COMMAND" &> /dev/null
+    then
+        if [ $# -ge 2 ]
+        then
+            echo $2
+        else
+            echo "'$COMMAND' is not available as as command, please fix and run then script again"
+        fi
+        exit
+    fi
+}
+
+# Ensure necessary commands are available
+check_if_command_exists lando
+check_if_command_exists curl
+check_if_command_exists unzip
+check_if_command_exists mutagen "Mutagen is necessary to use this plugin - https://mutagen.io/documentation/introduction/installation"
+
+if [ ! -d $PLUGINS_DIR ]
+then
+    echo "$PLUGINS_DIR does not exist."
+    exit 1
+fi
+
+curl -L "$ZIP_DOWNLOAD_URL" -o "$ZIP_DOWNLOAD_PATH"
+# Check to make sure file downloaded and is not 0 bytes
+if [ ! -s $ZIP_DOWNLOAD_PATH ]
+then
+    echo "There was an issue downloading $ZIP_DOWNLOAD_URL."
+    exit 1
+fi
+echo "Plugin downloaded"
+
+# Unzip to lando plugins directory
+unzip -q $ZIP_DOWNLOAD_PATH -d $PLUGINS_DIR
+# Delete zip file
+rm -rf $ZIP_DOWNLOAD_PATH
+# Remove old version of plugin
+rm -rf $PLUGIN_PATH
+# Rename directory to use underscore instead of dash
+mv "$PLUGINS_DIR/lando-mutagen" $PLUGIN_PATH
+
+# Check to make sure then plugin is detected by lando
+if lando config | grep '.lando/plugins/lando_mutagen/app.js' &> /dev/null
+then
+    echo "Plugin installed and detected in 'lando config'"
+    exit
+fi
+


### PR DESCRIPTION
My team has started using this plugin so I wrote a script to simplify installation a bit.  I based it off of what was already in the readme, here's what the script does:

- Check to make sure that `mutagen` is installed, link to installation instructions if not and exit script
- Download the latest plugin release
- Remove old version of the plugin at `~/.lando/plugins/lando_mutagen`
- Install latest version of the plugin at the same directory

I also added a `Mac Installation Script` section to `Installation` in the readme.